### PR TITLE
Use mkfs.fat as an alternative instead of mkdosfs (if not found)

### DIFF
--- a/tools/kernel/make_disk.sh
+++ b/tools/kernel/make_disk.sh
@@ -48,7 +48,7 @@ sudo losetup /dev/loop102 "${3}" -o 1048576   #  1  MB
 sudo losetup /dev/loop103 "${3}" -o 136314880 # 128 MB
 
 if [ -z "$4" ]; then
-	sudo mkdosfs -F32 -f 2 /dev/loop102
+	sudo mkdosfs -F32 -f 2 /dev/loop102 || sudo mkfs.fat -F32 -f 2 /dev/loop102
 	# sudo mkdosfs -F32 -f 2 /dev/loop103
 	sudo mke2fs -L "cavOS" /dev/loop103
 	sudo fatlabel /dev/loop102 LIMINE


### PR DESCRIPTION
Some package manager do it correctly when following general filesystem formatting tool naming convention. Like ```mkfs.ext4```, ```mkfs.btrfs``` and so on. On these systems FAT filesystem formatting tool would have proper name like ```mkfs.fat``` instead of mkdosfs. This is small change to fix disk make target, however, I see forward to generalizing formatting toolchain into special scripts instead of calling mkfs.* directly.