### PR TITLE
i386 toolchain + script quality

### DIFF
--- a/src/kernel/Makefile
+++ b/src/kernel/Makefile
@@ -1,24 +1,29 @@
-COMPILER = ~/opt/cross/bin/x86_64-cavos-gcc
-LINKER = ~/opt/cross/bin/x86_64-cavos-ld
-ASSEMBLER = nasm
+COMPILER		= 	~/opt/cross/bin/x86_64-cavos-gcc
+LINKER			= 	~/opt/cross/bin/x86_64-cavos-ld
+ASSEMBLER		= 	nasm
 # -w(no warnings) -g(dev)
-CFLAGS = -m64 -c -ffreestanding -Wall -Werror -fcommon -Iinclude/ -fPIE -mno-80387 \
-    -mno-mmx \
-    -mno-sse \
-		-nostartfiles \
-		-nostdlib \
-    -mno-sse2 \
-    -mno-red-zone -fno-stack-protector \
-    -fno-stack-check \
-    -fno-lto
-ASFLAGS = -f elf64
-LDFLAGS = -m elf_x86_64 \
-		-nostdlib \
-    -static \
-    -pie \
-    --no-dynamic-linker \
-    -z text \
-    -z max-page-size=0x1000 -T link.ld
+SH				=	bash
+QEMU			=	qemu-system-x86_64
+QEMU_IMG		=	qemu-img
+CFLAGS			=	-m64 -c -ffreestanding -Wall -Werror					\
+					-fcommon -Iinclude/ -fPIE -mno-80387					\
+					-mno-mmx												\
+					-mno-sse												\
+						-nostartfiles										\
+						-nostdlib											\
+					-mno-sse2												\
+					-mno-red-zone -fno-stack-protector						\
+					-fno-stack-check										\
+					-fno-lto
+ASFLAGS			=	-f elf64
+
+LDFLAGS			=	-m elf_x86_64											\
+					-nostdlib 												\
+					-static 												\
+					-pie 													\
+					--no-dynamic-linker										\
+					-z text													\
+					-z max-page-size=0x1000 -T link.ld
 
 TARGET = ../../target
 MOUNTPOINT = /cavosmnt
@@ -42,9 +47,14 @@ all: $(C_OBJS) $(ASM_OBJS) $(C_EXTRA_OBJS)
 	mkdir $(TARGET)/ -p
 	mkdir $(TARGET)/boot/ -p
 	$(LINKER) $(LDFLAGS) -o $(OUTPUT) $(C_OBJS) $(C_EXTRA_OBJS) $(ASM_OBJS)
-	
+
+MALLOC_CFLAGS	=	-DHAVE_MMAP=0 -DLACKS_TIME_H=1 -DLACKS_SYS_PARAM_H=1	\
+					-LACKS_STRING_H=0 -Dmalloc_getpagesize=4096				\
+					-DNO_MALLOC_STATS=1 -DMORECORE_CONTIGUOUS=0				\
+					-DUSE_LOCKS=2
+
 memory/malloc.o:memory/malloc.c
-	$(COMPILER) $(CFLAGS) memory/malloc.c -o memory/malloc.o -DHAVE_MMAP=0 -DLACKS_TIME_H=1 -DLACKS_SYS_PARAM_H=1 -LACKS_STRING_H=0 -Dmalloc_getpagesize=4096 -DNO_MALLOC_STATS=1 -DMORECORE_CONTIGUOUS=0 -DUSE_LOCKS=2
+	$(COMPILER) $(CFLAGS) $(MALLOC_CFLAGS) memory/malloc.c -o memory/malloc.o
 
 drivers/printf.o:drivers/printf.c
 	$(COMPILER) $(CFLAGS) drivers/printf.c -o drivers/printf.o -DPRINTF_INCLUDE_CONFIG_H=1
@@ -56,19 +66,16 @@ drivers/printf.o:drivers/printf.c
 	$(ASSEMBLER) $(ASFLAGS) -o $@ $(subst .asm.o,.asm,$@)
 
 disk:all
-	chmod +x $(TOOLS)/kernel/make_disk.sh
-	$(TOOLS)/kernel/make_disk.sh $(TARGET) $(MOUNTPOINT) $(TARGET_IMG) || (chmod +x $(TOOLS)/kernel/cleanup.sh && $(TOOLS)/kernel/cleanup.sh $(MOUNTPOINT))
+	$(SH) $(TOOLS)/kernel/make_disk.sh $(TARGET) $(MOUNTPOINT) $(TARGET_IMG) || $(SH) $(TOOLS)/kernel/cleanup.sh $(MOUNTPOINT)
 
 disk_dirty:all
-	chmod +x $(TOOLS)/kernel/make_disk.sh
-	$(TOOLS)/kernel/make_disk.sh $(TARGET) $(MOUNTPOINT) $(TARGET_IMG) yes || (chmod +x $(TOOLS)/kernel/cleanup.sh && $(TOOLS)/kernel/cleanup.sh $(MOUNTPOINT))
+	$(SH) $(TOOLS)/kernel/make_disk.sh $(TARGET) $(MOUNTPOINT) $(TARGET_IMG) yes || $(SH) $(TOOLS)/kernel/cleanup.sh $(MOUNTPOINT)
 
 vmware:disk
-	qemu-img convert $(TARGET_IMG) -O vmdk $(TARGET_VMWARE)
+	$(QEMU_IMG) convert $(TARGET_IMG) -O vmdk $(TARGET_VMWARE)
 
 tools:
-	chmod +x $(TOOLS)/toolchain/get_tools.sh
-	$(TOOLS)/toolchain/get_tools.sh
+	$(SH) $(TOOLS)/toolchain/get_tools.sh
 	
 clean:
 # rm -f $(TARGET)/obj/*.o
@@ -77,10 +84,34 @@ clean:
 #	rm -f $(TARGET_IMG) $(TARGET_VMWARE) $(TARGET_ISO)
 
 qemu:
-	qemu-system-x86_64 -d guest_errors -serial stdio -drive file=$(TARGET_IMG),format=raw,id=disk,if=none -device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 -m 1g -netdev user,id=mynet0 -net nic,model=rtl8139,netdev=mynet0
+	$(QEMU)																		\
+			-d guest_errors														\
+			-serial stdio														\
+			-drive file=$(TARGET_IMG),format=raw,id=disk,if=none 				\
+			-device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0			\
+			-m 1g -netdev user,id=mynet0										\
+			-net nic,model=rtl8139,netdev=mynet0
 
 qemu_dbg:
-	qemu-system-x86_64 -d guest_errors -no-shutdown -no-reboot -serial stdio -drive file=$(TARGET_IMG),format=raw,id=disk,if=none -device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 -m 8g -netdev user,id=mynet0,hostfwd=udp::5555-:69,hostfwd=tcp::5555-:69 -net nic,model=rtl8139,netdev=mynet0 -object filter-dump,id=id,netdev=mynet0,file=../../netdmp.pcapng -s
+	$(QEMU)																		\
+			-d guest_errors 													\
+			-no-shutdown														\
+			-no-reboot															\
+			-serial stdio														\
+			-drive file=$(TARGET_IMG),format=raw,id=disk,if=none				\
+			-device ahci,id=ahci												\
+			-device ide-hd,drive=disk,bus=ahci.0								\
+			-m 8g																\
+			-netdev user,id=mynet0,hostfwd=udp::5555-:69,hostfwd=tcp::5555-:69	\
+			-net nic,model=rtl8139,netdev=mynet0								\
+			-object filter-dump,id=id,netdev=mynet0,file=../../netdmp.pcapng	\
+			-s
 
 qemu_iso:
-	qemu-system-x86_64 -d guest_errors -serial stdio -drive file=$(TARGET_ISO),format=raw -m 1g -netdev user,id=mynet0 -net nic,model=rtl8139,netdev=mynet0
+	$(QEMU)																		\
+			-d guest_errors														\
+			-serial stdio														\
+			-drive file=$(TARGET_ISO),format=raw								\
+			-m 1g																\
+			-netdev user,id=mynet0												\
+			-net nic,model=rtl8139,netdev=mynet0

--- a/tools/toolchain/get_tools.sh
+++ b/tools/toolchain/get_tools.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Know where we at :p
+# script_env
 SCRIPT=$(realpath "$0")
-export SCRIPTPATH=$(dirname "$SCRIPT")
+SCRIPTPATH=$(dirname "$SCRIPT")
 cd "${SCRIPTPATH}"
 
 targets=("i386-cavos" "x86_64-cavos")

--- a/tools/toolchain/get_tools.sh
+++ b/tools/toolchain/get_tools.sh
@@ -1,78 +1,14 @@
 #!/usr/bin/env bash
-set -x # show cmds
-set -e # fail globally
 
 # Know where we at :p
 SCRIPT=$(realpath "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
+export SCRIPTPATH=$(dirname "$SCRIPT")
 cd "${SCRIPTPATH}"
 
-export PREFIX="$HOME/opt/cross"
-export TARGET=x86_64-cavos
-export SYSROOT="$SCRIPTPATH/../../target"
-export PATH="$PREFIX/bin:$PATH"
+targets=("i386-cavos" "x86_64-cavos")
 
-mkdir -p "$PREFIX"
+for i in "${targets[@]}"; do
+    export TARGET=$i
 
-# Ensure autotools
-if ! test -f "$HOME/opt/autotools_gcc/bin/automake"; then
-	chmod +x get_autotools.sh
-	./get_autotools.sh "1.15.1" "2.69" "$HOME/opt/autotools_gcc"
-	export PATH=$HOME/opt/autotools_gcc/bin:$PATH
-fi
-
-mkdir -p temporarydir
-cd temporarydir
-
-# Tarballs
-wget -nc https://ftp.gnu.org/gnu/binutils/binutils-2.38.tar.gz
-tar xpvf binutils-*.tar.gz
-wget -nc https://ftp.gnu.org/gnu/gcc/gcc-11.4.0/gcc-11.4.0.tar.gz
-tar xpvf gcc-*.tar.gz
-
-# Binutils
-cd binutils-2.38
-
-# Binutils: Pre-build
-patch -p1 <"${SCRIPTPATH}/../../patches/binutils.diff"
-cd ld/
-automake
-cd ../
-
-mkdir -p build
-cd build
-../configure --target="$TARGET" --prefix="$PREFIX" --with-sysroot="$SYSROOT" --enable-shared
-make -j$(nproc)
-make install
-cd ../../
-
-# GCC
-cd gcc-11.4.0
-
-# GCC: Pre-build
-patch -p1 <"${SCRIPTPATH}/../../patches/gcc.diff"
-cd libstdc++-v3/
-autoconf
-cd ../
-
-./contrib/download_prerequisites
-
-mkdir -p build
-cd build
-../configure --target="$TARGET" --prefix="$PREFIX" --enable-languages=c,c++ --with-sysroot="$SYSROOT" --enable-shared
-make all-gcc -j$(nproc)
-make all-target-libgcc -j$(nproc)
-make install-gcc
-make install-target-libgcc
-
-# Building musl alone is essential before libstdc++ is built & installed
-chmod +x "${SCRIPTPATH}/../../src/libs/musl/build.sh"
-"${SCRIPTPATH}/../../src/libs/musl/build.sh" --noreplace
-
-make all-target-libstdc++-v3 -j$(nproc)
-make install-target-libstdc++-v3
-
-cd ../../
-
-cd ../
-rm -rf temporarydir
+    bash make_tool.sh
+done

--- a/tools/toolchain/make_tool.sh
+++ b/tools/toolchain/make_tool.sh
@@ -2,6 +2,11 @@
 set -x # show cmds
 set -e # fail globally
 
+# script_env
+SCRIPT=$(realpath "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+cd "${SCRIPTPATH}"
+
 export PREFIX="$HOME/opt/cross"
 #export TARGET=x86_64-cavos
 export SYSROOT="$SCRIPTPATH/../../target"
@@ -11,8 +16,8 @@ mkdir -p "$PREFIX"
 
 # Ensure autotools
 if ! test -f "$HOME/opt/autotools_gcc/bin/automake"; then
-	chmod +x get_autotools.sh
-	./get_autotools.sh "1.15.1" "2.69" "$HOME/opt/autotools_gcc"
+	#chmod +x get_autotools.sh
+	bash get_autotools.sh "1.15.1" "2.69" "$HOME/opt/autotools_gcc"
 fi
 export PATH=$HOME/opt/autotools_gcc/bin:$PATH
 
@@ -63,8 +68,8 @@ make install-target-libgcc
 # Only build libc for x86_64, since user-land is 64-bit only for now
 if [ "$TARGET" = "x86_64-cavos" ]; then
 	# Building musl alone is essential before libstdc++ is built & installed
-	chmod +x "${SCRIPTPATH}/../../src/libs/musl/build.sh"
-	"${SCRIPTPATH}/../../src/libs/musl/build.sh" --noreplace
+	#chmod +x "${SCRIPTPATH}/../../src/libs/musl/build.sh"
+	bash "${SCRIPTPATH}/../../src/libs/musl/build.sh" --noreplace
 
 	make all-target-libstdc++-v3 -j$(nproc)
 	make install-target-libstdc++-v3

--- a/tools/toolchain/make_tool.sh
+++ b/tools/toolchain/make_tool.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -x # show cmds
+set -e # fail globally
+
+export PREFIX="$HOME/opt/cross"
+#export TARGET=x86_64-cavos
+export SYSROOT="$SCRIPTPATH/../../target"
+export PATH="$PREFIX/bin:$PATH"
+
+mkdir -p "$PREFIX"
+
+# Ensure autotools
+if ! test -f "$HOME/opt/autotools_gcc/bin/automake"; then
+	chmod +x get_autotools.sh
+	./get_autotools.sh "1.15.1" "2.69" "$HOME/opt/autotools_gcc"
+fi
+export PATH=$HOME/opt/autotools_gcc/bin:$PATH
+
+mkdir -p temporarydir
+cd temporarydir
+
+# Tarballs
+wget -nc https://ftp.gnu.org/gnu/binutils/binutils-2.38.tar.gz
+tar xpvf binutils-*.tar.gz
+wget -nc https://ftp.gnu.org/gnu/gcc/gcc-11.4.0/gcc-11.4.0.tar.gz
+tar xpvf gcc-*.tar.gz
+
+# Binutils
+cd binutils-2.38
+
+# Binutils: Pre-build
+patch -p1 <"${SCRIPTPATH}/../../patches/binutils.diff"
+cd ld/
+automake
+cd ../
+
+mkdir -p build
+cd build
+../configure --target="$TARGET" --prefix="$PREFIX" --with-sysroot="$SYSROOT" --enable-shared
+make -j$(nproc)
+make install
+cd ../../
+
+# GCC
+cd gcc-11.4.0
+
+# GCC: Pre-build
+patch -p1 <"${SCRIPTPATH}/../../patches/gcc.diff"
+cd libstdc++-v3/
+autoconf
+cd ../
+
+./contrib/download_prerequisites
+
+mkdir -p build
+cd build
+../configure --target="$TARGET" --prefix="$PREFIX" --enable-languages=c,c++ --with-sysroot="$SYSROOT" --enable-shared
+make all-gcc -j$(nproc)
+make all-target-libgcc -j$(nproc)
+make install-gcc
+make install-target-libgcc
+
+# Only build libc for x86_64, since user-land is 64-bit only for now
+if [ "$TARGET" = "x86_64-cavos" ]; then
+	# Building musl alone is essential before libstdc++ is built & installed
+	chmod +x "${SCRIPTPATH}/../../src/libs/musl/build.sh"
+	"${SCRIPTPATH}/../../src/libs/musl/build.sh" --noreplace
+
+	make all-target-libstdc++-v3 -j$(nproc)
+	make install-target-libstdc++-v3
+fi
+
+cd ../../
+
+cd ../
+rm -rf temporarydir


### PR DESCRIPTION
This PR enables building of i386 32-bit toolchain. Why would we need 32-bit toolchain? I must say that many people, including me, rely on this project as a toolchain bootstrap and find it useful for our different needs. Yes, it will increase build-time of toolchain, but on the bright with i386 toolchain many users could begin their journey into OS development very easy. I saw someone is making docker image of toolchain and I think it should be complete with 32-bit GCC as well.

Props to You for keeping all required patches for i386 in place.

For me personally, I need i386 toolchain to compile C code into 16 bit real-mode compatible way, and only i386 toolchain can do this.

This PR will be ground for my future bootloader I'm making for cavOS. You can see some funny stuff going in [mbr4ext2](https://github.com/mykola2312/mbr4ext2)

Aside from toolchain changes, Makefile is no more doing ```chmod +x``` on scripts in order to execute them, but rather directly calls ```$(SH)``` (which is by default set to ```bash```) to execute script. This is the right way to execute & source scripts. I must mention that changing file permissions in git repo will lead to strange git changes, if git config ```core.fileMode``` is not set to ```false```. So, starting from this PR, I advise You to always use ```bash <script.sh>``` instead of ```chmod +x script.sh``` + ```./script.sh```.

I have fixed bug where autotools check won't add them from ~/opt because it only did in if block, I moved it outside and now it always uses ~/opt version whenever possible, resolving cryptic autoconf issues.

Also, I moved commands like ```qemu-system-x86_64``` to their respective variables like ```$(QEMU)```, as well as formatted Makefile so it doesn't look ugly.

I many times tested ```make tools``` as well as ```make qemu``` and it works.

Sincerely,
[mykola2312](https://github.com/mykola2312/)