### PR TITLE
Fix formatting check workflow

### DIFF
--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -15,8 +15,5 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build tools
-        run: make tools
-
       - name: Check formatting
         run: make format_check

--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -15,5 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Build tools
+        run: make tools
+
       - name: Check formatting
         run: make format_check

--- a/tools/toolchain/get_formatter.sh
+++ b/tools/toolchain/get_formatter.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # set -x # show cmds
 set -e # fail globally
+mkdir -p ~/opt/
 
 # Embedded clang-format-19 (verified sha512sum from GitHub actions)
 CLANG_FORMAT_URI="https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-46b8640/clang-format-19_linux-amd64"


### PR DESCRIPTION
This PR shall fix the formatting check workflow, which currently fails because the toolchain is not present on the action container:
```
stat: cannot statx '/home/runner/opt/cross/bin/x86_64-cavos-gcc': No such file or directory
/home/runner/opt/clang-format-cavos: No such file or directory
make: *** [Makefile:108: format_prerequisites] Error 1
Error: Process completed with exit code 2.
```

My BBF (Big Beautiful Fix) will correct this issue, by building the toolchain before executing ``make format_check``. The downside of this is that the Action run takes around 13 minutes. However, as this is wasting microsofts resources we can ignore that honestly.